### PR TITLE
Add x-checker-data for automatic update of the modules in 22.08 & update modules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.yaml]
+max_line_length = 1000

--- a/0002-java-remove-version-build.patch
+++ b/0002-java-remove-version-build.patch
@@ -1,0 +1,42 @@
+commit 2bf4f8e07bcbebbde9330d9c9e6906c588ec6f19
+Author: Martin Pilarski <mpilarski@aqwe.de>
+Date:   Thu Feb 15 20:34:30 2024 +0100
+
+    Avoid unsetting of VERSION_BUILD by removing corresponding code.
+    VERSION_BUILD gets set via make/conf/version-numbers.conf.
+
+diff --git a/make/autoconf/jdk-version.m4 b/make/autoconf/jdk-version.m4
+index b75d2392980..59dc1a769a9 100644
+--- a/make/autoconf/jdk-version.m4
++++ b/make/autoconf/jdk-version.m4
+@@ -257,30 +257,6 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
+     fi
+   fi
+ 
+-  AC_ARG_WITH(version-build, [AS_HELP_STRING([--with-version-build],
+-      [Set version 'BUILD' field (build number) @<:@not specified@:>@])],
+-      [with_version_build_present=true], [with_version_build_present=false])
+-
+-  if test "x$with_version_build_present" = xtrue; then
+-    if test "x$with_version_build" = xyes; then
+-      AC_MSG_ERROR([--with-version-build must have a value])
+-    elif test "x$with_version_build" = xno; then
+-      # Interpret --without-* as empty string instead of the literal "no"
+-      VERSION_BUILD=
+-    elif test "x$with_version_build" = x; then
+-      VERSION_BUILD=
+-    else
+-      JDKVER_CHECK_AND_SET_NUMBER(VERSION_BUILD, $with_version_build)
+-    fi
+-  else
+-    if test "x$NO_DEFAULT_VERSION_PARTS" != xtrue; then
+-      # Default is to not have a build number.
+-      VERSION_BUILD=""
+-      # FIXME: Until all code can cope with an empty VERSION_BUILD, set it to 0.
+-      VERSION_BUILD=0
+-    fi
+-  fi
+-
+   AC_ARG_WITH(version-feature, [AS_HELP_STRING([--with-version-feature],
+       [Set version 'FEATURE' field (first number) @<:@current source value@:>@])],
+       [with_version_feature_present=true], [with_version_feature_present=false])

--- a/org.freedesktop.Sdk.Extension.openjdk17.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk17.yaml
@@ -1,4 +1,3 @@
----
 id: org.freedesktop.Sdk.Extension.openjdk17
 branch: '22.08'
 runtime: org.freedesktop.Sdk
@@ -43,7 +42,6 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk17/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=7
       - --with-version-pre=
       - --with-version-opt=
       - --with-vendor-version-string=21.9
@@ -71,15 +69,24 @@ modules:
     post-install:
       - (cd $FLATPAK_DEST/jvm && ln -s openjdk-17.* openjdk-17)
     sources:
-      - type: archive
-        url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9+9/OpenJDK17U-jdk-sources_17.0.9_9.tar.gz
-        sha256: 5849d187849e55931e2afd343ae30f10808be4524fece2d195d4d41e84905252
+      - type: git
+        url: https://github.com/adoptium/jdk17u.git
+        tag: jdk-17.0.9+9
+        commit: 9c16e89d275654cee98f5374434bea2097dda91e
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/adoptium/temurin17-binaries/releases/latest
+          is-main-source: true
+          tag-query: .tag_name
       - type: patch
         path: 0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
+      - type: patch
+        path: 0002-java-remove-version-build.patch
       - type: shell
         commands:
           - chmod a+x configure
           - sed -i -e "s|@prefix@|$FLATPAK_DEST|" make/autoconf/spec.gmk.in
+          - git describe --match jdk-17.*+* HEAD | sed -e 's/jdk-17.*+\(\)/VERSION_BUILD=\1/' >> make/conf/version-numbers.conf
   - name: cacerts
     buildsystem: simple
     sources:
@@ -97,6 +104,12 @@ modules:
         url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
         sha512: 4e74b382dd8271f9eac9fef69ba94751fb8a8356dbd995c4d642f2dad33de77bd37d4001d6c8f4f0ef6789529754968f0c1b6376668033c8904c6ec84543332a
+        x-checker-data:
+          type: anitya
+          project-id: 50
+          stable-only: true
+          is-main-source: false
+          url-template: http://archive.apache.org/dist/ant/binaries/apache-ant-$version-bin.tar.gz
     build-commands:
       - mkdir -p $FLATPAK_DEST/ant
       - tar xf apache-ant-bin.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/ant
@@ -111,6 +124,14 @@ modules:
         url: http://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
         sha512: deaa39e16b2cf20f8cd7d232a1306344f04020e1f0fb28d35492606f647a60fe729cc40d3cba33e093a17aed41bd161fe1240556d0f1b80e773abd408686217e
+        x-checker-data:
+          type: anitya
+          project-id: 1894
+          stable-only: true
+          is-main-source: false
+          url-template: http://archive.apache.org/dist/maven/maven-3/$version/binaries/apache-maven-$version-bin.tar.gz
+          versions:
+            <: 4.0.0
     build-commands:
       - mkdir -p $FLATPAK_DEST/maven
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven
@@ -124,6 +145,12 @@ modules:
         url: https://services.gradle.org/distributions/gradle-8.3-bin.zip
         dest-filename: gradle-bin.zip
         sha256: 591855b517fc635b9e04de1d05d5e76ada3f89f5fc76f87978d1b245b4f69225
+        x-checker-data:
+          type: json
+          url: https://services.gradle.org/versions/current
+          is-main-source: false
+          version-query: .version
+          url-query: .downloadUrl
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle

--- a/org.freedesktop.Sdk.Extension.openjdk17.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk17.yaml
@@ -71,8 +71,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk17u.git
-        tag: jdk-17.0.9+9
-        commit: 9c16e89d275654cee98f5374434bea2097dda91e
+        tag: jdk-17.0.10+7
+        commit: ca760c86642aa2e0d9b571aaabac054c0239fbdc
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin17-binaries/releases/latest
@@ -121,9 +121,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: deaa39e16b2cf20f8cd7d232a1306344f04020e1f0fb28d35492606f647a60fe729cc40d3cba33e093a17aed41bd161fe1240556d0f1b80e773abd408686217e
+        sha512: 706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -142,9 +142,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.3-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.6-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: 591855b517fc635b9e04de1d05d5e76ada3f89f5fc76f87978d1b245b4f69225
+        sha256: 9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c
         x-checker-data:
           type: json
           url: https://services.gradle.org/versions/current


### PR DESCRIPTION
Manually update modules since: `Note Flathub's hosted tool only checks the default branch`