### PR TITLE
Add `x-checker-data` for the JDK and update outdated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This extension contains the OpenJDK 17 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
 
-OpenJDK 17 is the current long-term support (LTS) version.
+OpenJDK 17 is the previous long-term support (LTS) version.
 
-For the previous LTS version, see the [OpenJDK 11](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11) extension.
+For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
 
 For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) extension.
 
@@ -12,24 +12,45 @@ For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/f
 
 You can bundle the JRE with your Flatpak application by adding this SDK extension to your Flatpak manifest and calling the install.sh script. For example:
 
-```
-{
-  "id" : "org.example.MyApp",
-  "branch" : "1.0",
-  "runtime" : "org.freedesktop.Platform",
-  "runtime-version" : "21.08",
-  "sdk" : "org.freedesktop.Sdk",
-  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk17" ],
-  "modules" : [ {
-    "name" : "openjdk",
-    "buildsystem" : "simple",
-    "build-commands" : [ "/usr/lib/sdk/openjdk17/install.sh" ]
-  }, {
-    "name" : "myapp",
-    "buildsystem" : "simple",
-    ....
-  } ]
-  ....
-  "finish-args" : [ "--env=PATH=/app/jre/bin:/usr/bin" ]
-}
+```yaml
+app-id: com.example.myapp
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk17
+command: myapp
+
+finish-args:
+  - --socket=x11
+  - --share=ipc
+  - --env=PATH=/app/jre/bin:/app/bin:/usr/bin
+  - --env=JAVA_HOME=/app/jre
+  # ...
+
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk17/install.sh
+
+  - name: myapp
+    buildsystem: simple
+    build-options:
+      env:
+        PATH: /app/bin:/usr/bin:/usr/lib/sdk/openjdk17/bin
+        JAVA_HOME: /usr/lib/sdk/openjdk17/jvm/openjdk-17
+    build-commands:
+      - install -Dm755 -t /app/bin myapp
+      - install -Dm644 -t /app/share/com.example.myapp myapp.jar
+      # ...
+    sources:
+      - type: archive
+        url: https://example.com/myapp/download/myapp-1.0.0.tar.gz
+        # ...
+      - type: script
+        dest-filename: myapp
+        commands:
+          - exec java -jar /app/share/com.example.myapp/myapp.jar $@
+      # ...
 ```

--- a/org.freedesktop.Sdk.Extension.openjdk17.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk17.yaml
@@ -26,12 +26,26 @@ modules:
         url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: c25dfbc334068a48c19c44ce39ad4b8427e309ae1cfa83f23c102e78b8a6dcc0
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/17/hotspot?os=linux&architecture=x64&image_type=jdk
+          version-query: .[0].version.semver
+          url-query: .[0].binary.package.link
+          versions:
+            - ==: 17
       - type: file
         only-arches:
           - aarch64
         url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6cc304
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/17/hotspot?os=linux&architecture=aarch64&image_type=jdk
+          version-query: .[0].version.semver
+          url-query: .[0].binary.package.link
+          versions:
+            - ==: 17
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java

--- a/org.freedesktop.Sdk.Extension.openjdk17.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk17.yaml
@@ -23,9 +23,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz
+        url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: c25dfbc334068a48c19c44ce39ad4b8427e309ae1cfa83f23c102e78b8a6dcc0
+        sha256: 9d4dd339bf7e6a9dcba8347661603b74c61ab2a5083ae67bf76da6285da8a778
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/17/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -36,9 +36,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz
+        url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.13_11.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6cc304
+        sha256: 0c17fa4f14c0d2cc9e9334f996fccdddc5da4459d768f3105c7ff0283c47bf62
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/17/hotspot?os=linux&architecture=aarch64&image_type=jdk
@@ -84,8 +84,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk17u.git
-        tag: jdk-17.0.12+7
-        commit: 833f65ecb304ce39061a957667ef39c318105489
+        tag: jdk-17.0.13+11
+        commit: eed263c8077e066a32d746fd188f2dee8c47b9ab
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin17-binaries/releases/latest
@@ -114,9 +114,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.tar.gz
+        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
-        sha512: 4e74b382dd8271f9eac9fef69ba94751fb8a8356dbd995c4d642f2dad33de77bd37d4001d6c8f4f0ef6789529754968f0c1b6376668033c8904c6ec84543332a
+        sha512: d78427aff207592c024ff1552dc04f7b57065a195c42d398fcffe7a0145e8d00cd46786f5aa52e77ab0fdf81334f065eb8011eecd2b48f7228e97ff4cb20d16c
         x-checker-data:
           type: anitya
           project-id: 50
@@ -134,9 +134,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 7d171def9b85846bf757a2cec94b7529371068a0670df14682447224e57983528e97a6d1b850327e4ca02b139abaab7fcb93c4315119e6f0ffb3f0cbc0d0b9a2
+        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -155,9 +155,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.9-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.10.2-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab
+        sha256: 31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
         x-checker-data:
           type: json
           url: https://services.gradle.org/versions/current


### PR DESCRIPTION
This also updates the example manifest in the README file.

If this gets accepted, I'll cherry-pick these changes for the 23.08 branch later.

Closes #41 
Closes #42 
Closes #44 
Closes #45