### PR TITLE
[branch/24.08] Update java, maven and gradle modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk17.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk17.yaml
@@ -26,26 +26,12 @@ modules:
         url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.17_10.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: 992f96e7995075ac7636bb1a8de52b0c61d71ed3137fafc979ab96b4ab78dd75
-        x-checker-data:
-          type: json
-          url: https://api.adoptium.net/v3/assets/latest/17/hotspot?os=linux&architecture=x64&image_type=jdk
-          version-query: .[0].version.semver
-          url-query: .[0].binary.package.link
-          versions:
-            - ==: 17
       - type: file
         only-arches:
           - aarch64
         url: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.17_10.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: dc29ca6d35beb4419b4b00419b8a3dfbf5ae551e1ae2b046b516d9a579d04533
-        x-checker-data:
-          type: json
-          url: https://api.adoptium.net/v3/assets/latest/17/hotspot?os=linux&architecture=aarch64&image_type=jdk
-          version-query: .[0].version.semver
-          url-query: .[0].binary.package.link
-          versions:
-            - ==: 17
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java

--- a/org.freedesktop.Sdk.Extension.openjdk17.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk17.yaml
@@ -70,8 +70,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk17u.git
-        tag: jdk-17.0.17+10
-        commit: 30ef840c3736270330fc0a26849c2456406facfe
+        tag: jdk-17.0.18+8
+        commit: 20a272cada273ceeec432dc027ddb62a93304143
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin17-binaries/releases/latest
@@ -121,9 +121,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
+        sha512: 0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -142,9 +142,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+        url: https://services.gradle.org/distributions/gradle-9.3.0-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
+        sha256: 0d585f69da091fc5b2beced877feab55a3064d43b8a1d46aeb07996b0915e0e0
         x-checker-data:
           type: json
           url: https://services.gradle.org/versions/current


### PR DESCRIPTION
java: Update jdk17u.git
maven: Update apache-maven-bin.tar.gz to 3.9.12
gradle: Update gradle-bin.zip to 9.3.0

Co-authored-by: guihkx <626206+guihkx@users.noreply.github.com>

(cherry picked from commit 5f8dd74ba79d787ee21b10890476d5799bd7f31a)