### PR TITLE
[branch/24.08] readme: OpenJDK 25 is the current LTS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This extension contains the OpenJDK 17 Java Runtime Environment (JRE) and Java D
 
 OpenJDK 17 is the previous long-term support (LTS) version.
 
-For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
+For the current LTS version, see the [OpenJDK 25](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk25) extension.
 
 For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) extension.
 


### PR DESCRIPTION
(cherry picked from commit a56b19df0f8411aec42071dd4c40de0b8df20ef8)