### PR TITLE
[branch/24.08] Update java, maven and gradle modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk17.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk17.yaml
@@ -70,8 +70,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk17u.git
-        tag: jdk-17.0.19+10
-        commit: 982d53c227943a511e8d61694feced764b71a6c1
+        tag: jdk-17.0.20-ga
+        commit: 8cbbca61432426a3441aa08838d930ef954ea1ba
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin17-binaries/releases/latest
@@ -121,9 +121,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 33d81e0ec785f0207e3e5e3ffb61863e1dca5784c15ac3fb5ff105f69cffbea484eb8d473ea60467a63f7b0570eef8622f2fed8eee96acbe668aa313391cddb3
+        sha512: 831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -142,9 +142,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+        url: https://services.gradle.org/distributions/gradle-9.6.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: 2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+        sha256: 9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
         x-checker-data:
           type: json
           url: https://services.gradle.org/versions/current


### PR DESCRIPTION
java: Update jdk17u.git to jdk-17.0.20-ga
maven: Update apache-maven-bin.tar.gz to 3.9.16
gradle: Update gradle-bin.zip to 9.6.1

(cherry picked from commit 96fc8cf67e95782a05e262674addc148c521de18)